### PR TITLE
Update package name ImageMagick to imagemagick

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Open [localhost:8080](http://localhost:8080) and enjoy!
 ### Manually from source
 1. Install ImageMagick and ghostscript from your package manager.
 ```bash
-sudo apt install ImageMagick ghostscript
+sudo apt install imagemagick ghostscript
 ```
 2. (Recommended) Use a virtual environment for your python dependencies.
 ```bash


### PR DESCRIPTION
ImageMagick  is wrong package name so I change it to imagemagick

Whewe run this command

sudo apt install ImageMagick ghostscript
 
it show this error

Unable to locate package ImageMagick